### PR TITLE
fix: display warning if picker custom component is missing

### DIFF
--- a/src/lib/DatePicker.tsx
+++ b/src/lib/DatePicker.tsx
@@ -34,6 +34,16 @@ export const DatePicker = ({
   useListener(ref, 'duetClose', duetClose);
 
   useEffect(() => {
+    if (!customElements.get('duet-date-picker')) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '<DateRangePicker> depends on @duetds/date-picker but could not be found.\n',
+        'See https://github.com/algolia/react-instantsearch-widget-date-range-picker#install for more information.'
+      );
+    }
+  }, []);
+
+  useEffect(() => {
     if (ref.current !== null) {
       (ref.current! as any).localization = localization;
     }


### PR DESCRIPTION
This PR displays a warning on the console if `@duetds/date-picker` has not been properly imported, as it currently only fails silently.

<img width="1278" alt="" src="https://user-images.githubusercontent.com/154633/146751073-6402b6eb-9bef-41dc-aae6-8a8b63747e72.png">

Feel free to adjust the copy if necessary.
